### PR TITLE
[codex] 修复安装状态文件导致签名失效

### DIFF
--- a/SovietExtension/Rely/install.sh
+++ b/SovietExtension/Rely/install.sh
@@ -755,7 +755,7 @@ backup_executable
 restore_clean_executable
 copy_framework
 insert_framework
-sign_app
 write_state_file
+sign_app
 verify_install
 print_done


### PR DESCRIPTION
## 问题

安装脚本当前先执行 `sign_app`，再写入 `.SovietExtension.install_state`。这会在签名完成后修改 `WeChat.app` 包内容，可能导致 `codesign --deep --strict` 校验失败。

## 修复

将 `write_state_file` 调整到 `sign_app` 之前，让安装状态文件被纳入最终签名封装。

## 验证

- `bash -n SovietExtension/Rely/install.sh`
- 已在本机修复版安装脚本上验证：`codesign -vvv --deep --strict /Applications/WeChat.app` 通过
