### PR TITLE
Fix chatroom names in revoke forwarding

### DIFF
--- a/SovietExtension/SovietExtension/ForwardToSelfPatch.h
+++ b/SovietExtension/SovietExtension/ForwardToSelfPatch.h
@@ -10,7 +10,7 @@
 //    RevokePatch 中 UpdateSessionCache hook 提供的群名缓存（YMCachedRoomName）
 //
 //  思路：撤回回调里拿到原始消息内容，构造 type=5 文本消息通过 SendMsg CGI
-//  发给自己。群聊群名从缓存取，未命中回退为 roomID。0 新增 hook 点。
+//  发给自己。群聊群名从缓存取，未命中回退为“未知群聊”。0 新增 hook 点。
 //
 
 #import <Foundation/Foundation.h>

--- a/SovietExtension/SovietExtension/ForwardToSelfPatch.mm
+++ b/SovietExtension/SovietExtension/ForwardToSelfPatch.mm
@@ -43,7 +43,7 @@
 //     +0x268(616) = 有效标志 (0=已删除)
 //
 //  ★ 群名获取（0 新增 hook/VM 地址，复用已有基础设施）：
-//     YMCachedRoomName(roomID) 查缓存，未命中回退为 roomID。
+//     YMCachedRoomName(roomID) 查缓存，未命中回退为“未知群聊”。
 //
 //  ★ 图片/视频/文件 转发（TODO，当前仅发文本通知）：
 //     当前只发送提醒，不实际转发媒体内容。
@@ -262,7 +262,7 @@ static NSString *YMBuildRevokeForwardNotice(NSString *sessionText,
 
     if ([sessionText containsString:@"@chatroom"]) {
         NSString *roomName = YMCachedRoomName(sessionText);
-        [notice appendFormat:@"群名:%@\n", roomName.length > 0 ? roomName : (sessionText.length > 0 ? sessionText : @"未知群聊")];
+        [notice appendFormat:@"群名:%@\n", roomName.length > 0 ? roomName : @"未知群聊"];
     }
 
     [notice appendFormat:@"撤回人:%@\n", revokerDisplay.length > 0 ? revokerDisplay : @"***"];

--- a/SovietExtension/SovietExtension/MenuManager.m
+++ b/SovietExtension/SovietExtension/MenuManager.m
@@ -173,7 +173,7 @@
 {
     [self ym_confirmToggleMenuItem:item
                    userDefaultsKey:kRevokeForwardToSelfRealSend
-                   informativeText:@"开启后，撤回的消息将转发到自己的会话，全设备同步。\n转发的消息要显示群名需同时开启「显示退群昵称」。\n注意：退群昵称在部分设备上可能闪退，如遇问题请关闭。\n重启微信生效。" needSave:YES];
+                   informativeText:@"开启后，撤回的消息将转发到自己的会话，全设备同步。\n转发的消息要显示群名需同时开启「退群监控」。\n注意：退群昵称在部分设备上可能闪退，如遇问题请关闭。\n重启微信生效。" needSave:YES];
 }
 
 - (void)onUseSystemWeb:(NSMenuItem *)item

--- a/SovietExtension/SovietExtension/RevokePatch.mm
+++ b/SovietExtension/SovietExtension/RevokePatch.mm
@@ -556,6 +556,11 @@ static BOOL YMIsGroupExitNicknameEnabled(void) {
     return YMFeatureGroupExitMonitorEnabled && YMFeatureGroupExitNicknameEnabled;
 }
 
+static BOOL YMShouldEnableRoomNameCache(void) {
+    return YMIsGroupExitMonitorEnabled() &&
+           (YMFeatureGroupExitNicknameEnabled || YMRevokeRealSendForwardEnabled());
+}
+
 static BOOL YMIsAntiRevokeEnabled(void) {
     return YMFeatureAntiRevokeEnabled;
 }
@@ -3218,10 +3223,10 @@ static void YMGroupExitUpdateSessionCacheHook(uint64_t a1, int64_t a2, int64_t a
             }
         }
 
-        if (YMIsGroupExitMonitorEnabled()) {
+        if (YMIsGroupExitNicknameEnabled()) {
             YMGroupExitFlushPreloadRooms("session_service UpdateSessionCache");
             YMGroupExitFlushPendingNotices("session_service UpdateSessionCache");
-        } else {
+        } else if (!YMIsGroupExitMonitorEnabled()) {
             YMGroupExitClearRuntimeStateIfDisabled("session_service UpdateSessionCache");
         }
     }
@@ -3298,7 +3303,7 @@ static BOOL YMPatchGroupExitMonitorWithSlide(intptr_t slide, NSString *source) {
     uintptr_t dbApplyTarget = YMRuntimeAddress(profile->groupExitDBApplyVA);
     uintptr_t fmessagePreTarget = YMRuntimeAddress(profile->groupExitFMessagePreVA);
     BOOL nicknameEnabled = YMIsGroupExitNicknameEnabled();
-    BOOL updateSessionCacheHookEnabled = nicknameEnabled;
+    BOOL updateSessionCacheHookEnabled = YMShouldEnableRoomNameCache();
     BOOL nicknamePreloadHookEnabled = nicknameEnabled;
 
     uintptr_t updateSessionCacheTarget = updateSessionCacheHookEnabled ? YMRuntimeAddress(profile->groupExitUpdateSessionCacheVA) : 0;
@@ -3340,8 +3345,10 @@ static BOOL YMPatchGroupExitMonitorWithSlide(intptr_t slide, NSString *source) {
                                                              "group exit session_service::UpdateSessionCache",
                                                              source);
     } else {
-        YMLog(@"[GroupExitMonitor] UpdateSessionCache hook skipped. nickname=%@ profile=%s",
+        YMLog(@"[GroupExitMonitor] UpdateSessionCache hook skipped. roomNameCache=%@ nickname=%@ revokeForward=%@ profile=%s",
+              updateSessionCacheHookEnabled ? @"ON" : @"OFF",
               nicknameEnabled ? @"ON" : @"OFF",
+              YMRevokeRealSendForwardEnabled() ? @"ON" : @"OFF",
               profile ? profile->displayName : "NULL");
     }
 


### PR DESCRIPTION
## Summary
- Fix revoke forwarding notices showing raw `@chatroom` IDs when room name cache misses.
- Enable the room-name cache hook when revoke forwarding is enabled together with group exit monitor.
- Keep nickname preload hooks behind the existing “显示退群昵称” switch and update related UI/log text.

## Test Plan
- `git diff --check`
- `bash -n SovietExtension/Rely/install.sh SovietExtension/Rely/uninstall.sh`

Fixes #18