### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 </p>
 
 <p align="center">
-  <img src="https://api.star-history.com/svg?repos=MustangYM/SovietExtension&type=Date" width="600" alt="SovietExtension Effect 3" />
+  <img src="https://star-history.dera.page/svg?repos=MustangYM/SovietExtension&type=Date" width="600" alt="SovietExtension Effect 3" />
 </p>
 
 ---


### PR DESCRIPTION
The star history chart in the README is currently broken. Update its URL so the repository star history is displayed correctly again.